### PR TITLE
RegEx fix: Discord domain changed

### DIFF
--- a/bot/utils/processor.py
+++ b/bot/utils/processor.py
@@ -51,7 +51,7 @@ COLORS = [
     0x005C73,
     0x7C29A6,
 ]
-WH_REGEX = r"discordapp\.com\/api\/webhooks\/(?P<id>\d+)\/(?P<token>.+)"
+WH_REGEX = r"discord(app)?\.com\/api\/webhooks\/(?P<id>\d+)\/(?P<token>.+)"
 
 
 def worth_posting_location(location, coordinates):


### PR DESCRIPTION
Discord changed their domain from discordapp.com to discord.com. Adjusted code to accept both.